### PR TITLE
Small addition to work as pipelined (only for non-LA)

### DIFF
--- a/hardware/src/iob_picorv32.v
+++ b/hardware/src/iob_picorv32.v
@@ -30,24 +30,24 @@ module iob_picorv32
     parameter ADDR_W=32,
     parameter DATA_W=32
     )
-  (
-   input               clk,
-   input               rst,
-   input               boot,
-   output              trap,
+   (
+    input               clk,
+    input               rst,
+    input               boot,
+    output              trap,
 
-   // instruction bus
-   output [`REQ_W-1:0] ibus_req,
-   input [`RESP_W-1:0] ibus_resp,
+    // instruction bus
+    output [`REQ_W-1:0] ibus_req,
+    input [`RESP_W-1:0] ibus_resp,
 
-   // data bus
-   output [`REQ_W-1:0] dbus_req,
-   input [`RESP_W-1:0] dbus_resp
-   );
+    // data bus
+    output [`REQ_W-1:0] dbus_req,
+    input [`RESP_W-1:0] dbus_resp
+    );
 
    //create picorv32 native interface concat buses
-   wire [1*`REQ_W-1:0]                                  cpu_req, cpu_i_req, cpu_d_req;
-   wire [1*`RESP_W-1:0]                                 cpu_resp;
+   wire [1*`REQ_W-1:0]  cpu_req, cpu_i_req, cpu_d_req;
+   wire [1*`RESP_W-1:0] cpu_resp;
 
    //modify addresses if DDR used according to boot status
 `ifdef RUN_DDR_USE_SRAM
@@ -59,22 +59,21 @@ module iob_picorv32
 `endif
 
    //split cpu bus into instruction and data buses
-   wire                                                 cpu_instr;
-   assign cpu_i_req = cpu_instr? cpu_req: {`REQ_W{1'b0}};
-   assign cpu_d_req = !cpu_instr? cpu_req: {`REQ_W{1'b0}};
+   wire                 cpu_instr;
+   assign cpu_i_req = cpu_instr?  cpu_req : {`REQ_W{1'b0}};
+   assign cpu_d_req = !cpu_instr? cpu_req : {`REQ_W{1'b0}};
    assign cpu_resp = cpu_instr? ibus_resp: dbus_resp;
    
-   reg                                                  cpu_valid;
-   assign cpu_req[`valid(0)] = cpu_valid;
+   wire                 cpu_valid;
+   wire                 cpu_ready = cpu_resp[`ready(0)];
+   
 `ifdef LA_IF
-   wire                                                 mem_la_read, mem_la_write;
+   wire                 mem_la_read, mem_la_write;
    always @(posedge clk) cpu_valid <= mem_la_read | mem_la_write;
 `else
-   wire                                                 cpu_valid_int;
-   reg                                                  cpu_valid_reg;
-   always @* cpu_valid = cpu_valid_int & ~cpu_valid_reg;
-   assign cpu_req[`valid(0)] = cpu_valid;
-   always @(posedge clk) cpu_valid_reg <= cpu_valid_int;
+   wire                 cpu_valid_int;
+   reg                  cpu_valid_reg;
+   assign cpu_req[`valid(0)] = cpu_valid & ~cpu_ready;
 `endif
    
 
@@ -92,7 +91,7 @@ module iob_picorv32
 		  .mem_instr     (cpu_instr),
 `ifndef LA_IF
 		  //memory interface
-		  .mem_valid     (cpu_valid_int),
+                  .mem_valid     (cpu_valid),
 		  .mem_addr      (cpu_req[`address(0, `ADDR_W)]),
 		  .mem_wdata     (cpu_req[`wdata(0)]),
 		  .mem_wstrb     (cpu_req[`wstrb(0)]),


### PR DESCRIPTION
- Only was added the combinatorial logic for the wrapper's valid (to go Low when receiving the ready).
- Was only added for the non-LA configuration.
- Tested only with "make sim" for both USE_DDR & RUN_DDR and without.
- Some unecessary registers were removed