### PR TITLE
feat(params): Remove iob-soc macros from params

### DIFF
--- a/iob_picorv32_setup.py
+++ b/iob_picorv32_setup.py
@@ -21,9 +21,9 @@ confs = \
     # Parameters
     {'name':'ADDR_W', 'type':'P', 'val':'32', 'min':'1', 'max':'?', 'descr':'description here'},
     {'name':'DATA_W', 'type':'P', 'val':'32', 'min':'1', 'max':'?', 'descr':'description here'},
-    {'name':'V_BIT', 'type':'P', 'val':'`V_BIT', 'min':'1', 'max':'?', 'descr':'description here'},
-    {'name':'E_BIT', 'type':'P', 'val':'`E_BIT', 'min':'1', 'max':'?', 'descr':'description here'},
-    {'name':'P_BIT', 'type':'P', 'val':'`P_BIT', 'min':'1', 'max':'?', 'descr':'description here'},
+    {'name':'V_BIT', 'type':'P', 'val':'68', 'min':'1', 'max':'?', 'descr':'description here'},
+    {'name':'E_BIT', 'type':'P', 'val':'67', 'min':'1', 'max':'?', 'descr':'description here'},
+    {'name':'P_BIT', 'type':'P', 'val':'66', 'min':'1', 'max':'?', 'descr':'description here'},
     {'name':'USE_COMPRESSED', 'type':'P', 'val':'1', 'min':'0', 'max':'1', 'descr':'description here'},
     {'name':'USE_MUL_DIV', 'type':'P', 'val':'1', 'min':'0', 'max':'1', 'descr':'description here'},
     {'name':'RUN_EXTMEM', 'type':'P', 'val':'0', 'min':'0', 'max':'1', 'descr':'Select if configured for usage with external memory.'},


### PR DESCRIPTION
- Removed `V_BIT`, `E_BIT` and `P_BIT` macros as they are specific to iob-soc (currently located in iob_soc.vh) and are not known by iob-picorv32. Replaced them by the default values used in iob-soc.