### PR TITLE
Fix CPU `avalid` signal detection.

### DIFF
--- a/hardware/src/iob_picorv32.v
+++ b/hardware/src/iob_picorv32.v
@@ -109,7 +109,7 @@ module iob_picorv32 #(
                     .clk_i (clk_i),
                     .arst_i(rst_i),
                     .cke_i (cke_i),
-                    .bit_i (cpu_avalid),
+                    .bit_i (cpu_avalid & ~cpu_ack),
                     .detected_o(cpu_avalid_p)
                     );
    


### PR DESCRIPTION
This commit allows the `iob_edge_detect` module of the `avalid` signal to detect address changes even when the CPU maintains the `cpu_avalid` signal set.