### PR TITLE
Fix py2hw setup process using previously agreed-upon py2hw syntax

### DIFF
--- a/hardware/src/iob_picorv32.v
+++ b/hardware/src/iob_picorv32.v
@@ -1,80 +1,79 @@
 `timescale 1 ns / 1 ps
 `include "iob_picorv32_conf.vh"
-`include "iob_utils.vh"
 
 module iob_picorv32 #(
-   `include "iob_picorv32_params.vs"
+    `include "iob_picorv32_params.vs"
 ) (
-   input  clk_i,
-   input  arst_i,
-   input  cke_i,
-   input  boot_i,
-   output trap_o,
+    input  clk_i,
+    input  arst_i,
+    input  cke_i,
+    input  boot_i,
+    output trap_o,
 
-   // instruction bus
-   `include "iob_picorv32_ibus_iob_m_port.vs"
+    // instruction bus
+    `include "iob_picorv32_ibus_iob_m_port.vs"
 
-   // data bus
-   `include "iob_picorv32_dbus_iob_m_port.vs"
+    // data bus
+    `include "iob_picorv32_dbus_iob_m_port.vs"
 );
 
-   //picorv32 native interface wires
-   wire                cpu_instr;
-   wire                cpu_valid;
-   wire [  ADDR_W-1:0] cpu_addr;
-   wire [DATA_W/8-1:0] cpu_wstrb;
-   wire [  DATA_W-1:0] cpu_wdata;
-   wire [  DATA_W-1:0] cpu_rdata;
-   wire                cpu_ready;
+  //picorv32 native interface wires
+  wire                cpu_instr;
+  wire                cpu_valid;
+  wire [  ADDR_W-1:0] cpu_addr;
+  wire [DATA_W/8-1:0] cpu_wstrb;
+  wire [  DATA_W-1:0] cpu_wdata;
+  wire [  DATA_W-1:0] cpu_rdata;
+  wire                cpu_ready;
 
-   //split cpu bus into ibus and dbus
-   wire                iob_i_valid;
-   wire                 iob_d_valid;
+  //split cpu bus into ibus and dbus
+  wire                iob_i_valid;
+  wire                iob_d_valid;
 
-   //iob interface wires
-   wire                iob_i_rvalid;
-   wire                iob_d_rvalid;
-   wire                iob_d_ready;
+  //iob interface wires
+  wire                iob_i_rvalid;
+  wire                iob_d_rvalid;
+  wire                iob_d_ready;
 
-   //compute the instruction bus request
-   assign ibus_iob_valid_o = iob_i_valid;
-   generate
-      if (USE_EXTMEM) begin : g_use_extmem
-         assign ibus_iob_addr_o = {~boot_i, cpu_addr[ADDR_W-2:0]};
-      end else begin : g_not_use_extmem
-         assign ibus_iob_addr_o = cpu_addr;
-      end
-   endgenerate
-   assign ibus_iob_wdata_o = {DATA_W{1'b0}};
-   assign ibus_iob_wstrb_o = {(DATA_W/8){1'b0}};
+  //compute the instruction bus request
+  assign ibus_iob_valid_o = iob_i_valid;
+  generate
+    if (USE_EXTMEM) begin : g_use_extmem
+      assign ibus_iob_addr_o = {~boot_i, cpu_addr[ADDR_W-2:0]};
+    end else begin : g_not_use_extmem
+      assign ibus_iob_addr_o = cpu_addr;
+    end
+  endgenerate
+  assign ibus_iob_wdata_o = {DATA_W{1'b0}};
+  assign ibus_iob_wstrb_o = {(DATA_W/8){1'b0}};
 
-   //compute the data bus request
-   assign dbus_iob_valid_o = iob_d_valid;
-   assign dbus_iob_addr_o = cpu_addr;
-   assign dbus_iob_wdata_o = cpu_wdata;
-   assign dbus_iob_wstrb_o = cpu_wstrb;
+  //compute the data bus request
+  assign dbus_iob_valid_o = iob_d_valid;
+  assign dbus_iob_addr_o = cpu_addr;
+  assign dbus_iob_wdata_o = cpu_wdata;
+  assign dbus_iob_wstrb_o = cpu_wstrb;
 
-   //split cpu bus into instruction and data buses
-   assign iob_i_valid  = cpu_instr & cpu_valid;
+  //split cpu bus into instruction and data buses
+  assign iob_i_valid  = cpu_instr & cpu_valid;
 
-   assign iob_d_valid  = (~cpu_instr) & cpu_valid & (~iob_d_rvalid);
+  assign iob_d_valid  = (~cpu_instr) & cpu_valid & (~iob_d_rvalid);
 
-   //extract iob interface wires from concatenated buses
-   assign iob_d_rvalid = dbus_iob_rvalid_i;
-   assign iob_i_rvalid = ibus_iob_rvalid_i;
-   assign iob_d_ready  = dbus_iob_ready_i;
+  //extract iob interface wires from concatenated buses
+  assign iob_d_rvalid = dbus_iob_rvalid_i;
+  assign iob_i_rvalid = ibus_iob_rvalid_i;
+  assign iob_d_ready  = dbus_iob_ready_i;
 
-   //cpu rdata and ready
-   assign cpu_rdata    = cpu_instr ? ibus_iob_rdata_i : dbus_iob_rdata_i;
-   assign cpu_ready    = cpu_instr ? iob_i_rvalid : |cpu_wstrb? iob_d_ready : iob_d_rvalid;
+  //cpu rdata and ready
+  assign cpu_rdata    = cpu_instr ? ibus_iob_rdata_i : dbus_iob_rdata_i;
+  assign cpu_ready    = cpu_instr ? iob_i_rvalid : |cpu_wstrb? iob_d_ready : iob_d_rvalid;
 
-   //intantiate the PicoRV32 CPU
-   picorv32 #(
+  //intantiate the PicoRV32 CPU
+  picorv32 #(
       .COMPRESSED_ISA (USE_COMPRESSED),
       .ENABLE_FAST_MUL(USE_MUL_DIV),
       .ENABLE_DIV     (USE_MUL_DIV),
       .BARREL_SHIFTER (1)
-   ) picorv32_core (
+  ) picorv32_core (
       .clk         (clk_i),
       .resetn      (~arst_i),
       .trap        (trap_o),
@@ -106,6 +105,6 @@ module iob_picorv32 #(
       .eoi         (),
       .trace_valid (),
       .trace_data  ()
-   );
+  );
 
 endmodule

--- a/iob_picorv32.py
+++ b/iob_picorv32.py
@@ -9,6 +9,7 @@ from iob_edge_detect import iob_edge_detect
 
 class iob_picorv32(iob_module):
     def __init__(self):
+        super().__init__()
         self.name = 'iob_picorv32'
         self.version = 'V0.10'
         self.setup_dir = os.path.dirname(__file__)

--- a/iob_picorv32.py
+++ b/iob_picorv32.py
@@ -6,6 +6,7 @@ from iob_core import iob_core
 class iob_picorv32(iob_core):
     def __init__(self, *args, **kwargs):
         self.set_default_attribute("version", "0.1")
+        self.set_default_attribute("generate_hw", False)
 
         self.create_conf(
             name='ADDR_W',

--- a/iob_picorv32.py
+++ b/iob_picorv32.py
@@ -26,7 +26,7 @@ class iob_picorv32(iob_module):
             {'name':'USE_MUL_DIV', 'type':'P', 'val':'1', 'min':'0', 'max':'1', 'descr':'description here'},
             {'name':'USE_EXTMEM', 'type':'P', 'val':'0', 'min':'0', 'max':'1', 'descr':'Select if configured for usage with external memory.'},
         ]
-        self.ios += [
+        self.ios = [
             {
                 "name": "clk_rst",
                 "type": "slave",
@@ -95,4 +95,4 @@ class iob_picorv32(iob_module):
                     },
                 ]}
         ]
-        self.block_groups += []
+        self.block_groups = []

--- a/iob_picorv32.py
+++ b/iob_picorv32.py
@@ -13,8 +13,8 @@ class iob_picorv32(iob_module):
         self.version = 'V0.10'
         self.setup_dir = os.path.dirname(__file__)
         self.submodule_list = [
-            iob_reg,
-            iob_edge_detect,
+            iob_reg(),
+            iob_edge_detect(),
         ]
         self.confs = [
             # Macros

--- a/iob_picorv32.py
+++ b/iob_picorv32.py
@@ -1,97 +1,132 @@
 #!/usr/bin/env python3
 
-import os
-
-from iob_module import iob_module
-from iob_reg import iob_reg
-from iob_edge_detect import iob_edge_detect
+from iob_core import iob_core
 
 
-class iob_picorv32(iob_module):
-    def __init__(self):
-        super().__init__()
-        self.version = 'V0.10'
-        self.submodule_list = [
-            iob_reg(),
-            iob_edge_detect(),
-        ]
-        self.confs = [
-            # Macros
+class iob_picorv32(iob_core):
+    def __init__(self, *args, **kwargs):
+        self.set_default_attribute("version", "0.1")
 
-            # Parameters
-            {'name':'ADDR_W', 'type':'P', 'val':'32', 'min':'1', 'max':'?', 'descr':'description here'},
-            {'name':'DATA_W', 'type':'P', 'val':'32', 'min':'1', 'max':'?', 'descr':'description here'},
-            {'name':'USE_COMPRESSED', 'type':'P', 'val':'1', 'min':'0', 'max':'1', 'descr':'description here'},
-            {'name':'USE_MUL_DIV', 'type':'P', 'val':'1', 'min':'0', 'max':'1', 'descr':'description here'},
-            {'name':'USE_EXTMEM', 'type':'P', 'val':'0', 'min':'0', 'max':'1', 'descr':'Select if configured for usage with external memory.'},
-        ]
-        self.ios = [
-            {
-                "name": "clk_rst",
-                "type": "slave",
-                "port_prefix": "",
-                "wire_prefix": "",
-                "descr": "Clock and reset",
-                "ports": [],
-            },
-            {
-                'name': 'general',
-                "type": "master",
-                "port_prefix": "",
-                "wire_prefix": "",
-                'descr':'General interface signals',
-                'ports': [
-                    {
-                        'name':"boot",
-                        'direction':"input",
-                        'width':'1',
-                        'descr':"CPU boot input"
-                    },
-                    {
-                        'name':"trap",
-                        'direction':"output",
-                        'width':'1',
-                        'descr':"CPU trap output"
-                    },
-                ]},
-            {
-                'name': 'instruction_bus',
-                "type": "master",
-                "port_prefix": "",
-                "wire_prefix": "",
-                'descr':'Instruction bus',
-                'ports': [
-                    {
-                        'name':"ibus_req",
-                        'direction':"output",
-                        'width':'`REQ_W',
-                        'descr':"Instruction bus request"},
-                    {
-                        'name':"ibus_resp",
-                        'direction':"input",
-                        'width':'`RESP_W',
-                        'descr':"Instruction bus response"
-                    },
-                ]},
-            {
-                'name': 'data_bus',
-                "type": "master",
-                "port_prefix": "",
-                "wire_prefix": "",
-                'descr':'Data bus',
-                'ports': [
-                    {
-                        'name':"dbus_req",
-                        'direction':"output",
-                        'width':'`REQ_W',
-                        'descr':"Data bus request"
-                    },
-                    {
-                        'name':"dbus_resp",
-                        'direction':"input",
-                        'width':'`RESP_W',
-                        'descr':"Data bus response"
-                    },
-                ]}
-        ]
-        self.block_groups = []
+        self.create_conf(
+            name='ADDR_W',
+            type='P',
+            val='32',
+            min='1',
+            max='?',
+            descr='description here',
+        )
+        self.create_conf(
+            name='DATA_W',
+            type='P',
+            val='32',
+            min='1',
+            max='?',
+            descr='description here',
+        )
+        self.create_conf(
+            name='USE_COMPRESSED',
+            type='P',
+            val='1',
+            min='0',
+            max='1',
+            descr='description here',
+        )
+        self.create_conf(
+            name='USE_MUL_DIV',
+            type='P',
+            val='1',
+            min='0',
+            max='1',
+            descr='description here',
+        )
+        self.create_conf(
+            name='USE_EXTMEM',
+            type='P',
+            val='0',
+            min='0',
+            max='1',
+            descr='Select if configured for usage with external memory.',
+        )
+
+        self.create_port(
+            name="clk_rst",
+            type="slave",
+            port_prefix="",
+            wire_prefix="",
+            descr="Clock and reset",
+            signals=[],
+        ),
+        self.create_port(
+            name='general',
+            type="master",
+            port_prefix="",
+            wire_prefix="",
+            descr='General interface signals',
+            signals=[
+                {
+                    'name': "boot",
+                    'direction': "input",
+                    'width': '1',
+                    'descr': "CPU boot input"
+                },
+                {
+                    'name': "trap",
+                    'direction': "output",
+                    'width': '1',
+                    'descr': "CPU trap output"
+                },
+            ]
+        ),
+        self.create_port(
+            name='instruction_bus',
+            type="master",
+            port_prefix="",
+            wire_prefix="",
+            descr='Instruction bus',
+            signals=[
+                {
+                    'name': "ibus_req",
+                    'direction': "output",
+                    'width': '`REQ_W',
+                    'descr': "Instruction bus request"},
+                {
+                    'name': "ibus_resp",
+                    'direction': "input",
+                    'width': '`RESP_W',
+                    'descr': "Instruction bus response"
+                },
+            ]
+        ),
+        self.create_port(
+            name='data_bus',
+            type="master",
+            port_prefix="",
+            wire_prefix="",
+            descr='Data bus',
+            signals=[
+                {
+                    'name': "dbus_req",
+                    'direction': "output",
+                    'width': '`REQ_W',
+                    'descr': "Data bus request"
+                },
+                {
+                    'name': "dbus_resp",
+                    'direction': "input",
+                    'width': '`RESP_W',
+                    'descr': "Data bus response"
+                },
+            ]
+        )
+
+        self.create_instance(
+            "iob_reg",
+            "iob_reg_inst",
+        )
+
+        self.create_instance(
+            "iob_edge_detect",
+            "iob_edge_detect_inst",
+        )
+
+        super().__init__(*args, **kwargs)

--- a/iob_picorv32.py
+++ b/iob_picorv32.py
@@ -6,106 +6,93 @@ from iob_module import iob_module
 from iob_reg import iob_reg
 from iob_edge_detect import iob_edge_detect
 
-class iob_picorv32(iob_module):
-    name = 'iob_picorv32'
-    version = 'V0.10'
-    setup_dir = os.path.dirname(__file__)
 
-    @classmethod
-    def _create_submodules_list(cls):
-        ''' Create submodules list with dependencies of this module
-        '''
-        super()._create_submodules_list([
+class iob_picorv32(iob_module):
+    def __init__(self):
+        self.name = 'iob_picorv32'
+        self.version = 'V0.10'
+        self.setup_dir = os.path.dirname(__file__)
+        self.submodule_list = [
             iob_reg,
             iob_edge_detect,
-        ])
+        ]
+        self.confs = [
+            # Macros
 
-    @classmethod
-    def _setup_confs(cls):
-        super()._setup_confs([
-                # Macros
-
-                # Parameters
-                {'name':'ADDR_W', 'type':'P', 'val':'32', 'min':'1', 'max':'?', 'descr':'description here'},
-                {'name':'DATA_W', 'type':'P', 'val':'32', 'min':'1', 'max':'?', 'descr':'description here'},
-                {'name':'USE_COMPRESSED', 'type':'P', 'val':'1', 'min':'0', 'max':'1', 'descr':'description here'},
-                {'name':'USE_MUL_DIV', 'type':'P', 'val':'1', 'min':'0', 'max':'1', 'descr':'description here'},
-                {'name':'USE_EXTMEM', 'type':'P', 'val':'0', 'min':'0', 'max':'1', 'descr':'Select if configured for usage with external memory.'},
-            ])
-
-    @classmethod
-    def _setup_ios(cls):
-      
-      cls.ios += [
-          {
-              "name": "clk_rst",
-              "type": "slave",
-              "port_prefix": "",
-              "wire_prefix": "",
-              "descr": "Clock and reset",
-              "ports": [],
-          },
-          {
-              'name': 'general',
-              "type": "master",
-              "port_prefix": "",
-              "wire_prefix": "",
-              'descr':'General interface signals',
-              'ports': [
-                  {
-                      'name':"boot",
-                      'direction':"input",
-                      'width':'1',
-                      'descr':"CPU boot input"
-                  },
-                  {
-                      'name':"trap",
-                      'direction':"output",
-                      'width':'1',
-                      'descr':"CPU trap output"
-                  },
-              ]},
-          {
-              'name': 'instruction_bus',
-              "type": "master",
-              "port_prefix": "",
-              "wire_prefix": "",
-              'descr':'Instruction bus',
-              'ports': [
-                  {
-                      'name':"ibus_req",
-                      'direction':"output",
-                      'width':'`REQ_W',
-                      'descr':"Instruction bus request"},
-                  {
-                      'name':"ibus_resp",
-                      'direction':"input",
-                      'width':'`RESP_W',
-                      'descr':"Instruction bus response"
-                  },
-              ]},
-          {
-              'name': 'data_bus',
-              "type": "master",
-              "port_prefix": "",
-              "wire_prefix": "",
-              'descr':'Data bus',
-              'ports': [
-                  {
-                      'name':"dbus_req",
-                      'direction':"output",
-                      'width':'`REQ_W',
-                      'descr':"Data bus request"
-                  },
-                  {
-                      'name':"dbus_resp",
-                      'direction':"input",
-                      'width':'`RESP_W',
-                      'descr':"Data bus response"
-                  },
-              ]}
-      ]
-
-    @classmethod
-    def _setup_block_groups(cls):
-        cls.block_groups += []
+            # Parameters
+            {'name':'ADDR_W', 'type':'P', 'val':'32', 'min':'1', 'max':'?', 'descr':'description here'},
+            {'name':'DATA_W', 'type':'P', 'val':'32', 'min':'1', 'max':'?', 'descr':'description here'},
+            {'name':'USE_COMPRESSED', 'type':'P', 'val':'1', 'min':'0', 'max':'1', 'descr':'description here'},
+            {'name':'USE_MUL_DIV', 'type':'P', 'val':'1', 'min':'0', 'max':'1', 'descr':'description here'},
+            {'name':'USE_EXTMEM', 'type':'P', 'val':'0', 'min':'0', 'max':'1', 'descr':'Select if configured for usage with external memory.'},
+        ]
+        self.ios += [
+            {
+                "name": "clk_rst",
+                "type": "slave",
+                "port_prefix": "",
+                "wire_prefix": "",
+                "descr": "Clock and reset",
+                "ports": [],
+            },
+            {
+                'name': 'general',
+                "type": "master",
+                "port_prefix": "",
+                "wire_prefix": "",
+                'descr':'General interface signals',
+                'ports': [
+                    {
+                        'name':"boot",
+                        'direction':"input",
+                        'width':'1',
+                        'descr':"CPU boot input"
+                    },
+                    {
+                        'name':"trap",
+                        'direction':"output",
+                        'width':'1',
+                        'descr':"CPU trap output"
+                    },
+                ]},
+            {
+                'name': 'instruction_bus',
+                "type": "master",
+                "port_prefix": "",
+                "wire_prefix": "",
+                'descr':'Instruction bus',
+                'ports': [
+                    {
+                        'name':"ibus_req",
+                        'direction':"output",
+                        'width':'`REQ_W',
+                        'descr':"Instruction bus request"},
+                    {
+                        'name':"ibus_resp",
+                        'direction':"input",
+                        'width':'`RESP_W',
+                        'descr':"Instruction bus response"
+                    },
+                ]},
+            {
+                'name': 'data_bus',
+                "type": "master",
+                "port_prefix": "",
+                "wire_prefix": "",
+                'descr':'Data bus',
+                'ports': [
+                    {
+                        'name':"dbus_req",
+                        'direction':"output",
+                        'width':'`REQ_W',
+                        'descr':"Data bus request"
+                    },
+                    {
+                        'name':"dbus_resp",
+                        'direction':"input",
+                        'width':'`RESP_W',
+                        'descr':"Data bus response"
+                    },
+                ]}
+        ]
+        self.block_groups += []

--- a/iob_picorv32.py
+++ b/iob_picorv32.py
@@ -11,7 +11,6 @@ class iob_picorv32(iob_module):
     def __init__(self):
         super().__init__()
         self.version = 'V0.10'
-        self.setup_dir = os.path.dirname(__file__)
         self.submodule_list = [
             iob_reg(),
             iob_edge_detect(),

--- a/iob_picorv32.py
+++ b/iob_picorv32.py
@@ -10,7 +10,6 @@ from iob_edge_detect import iob_edge_detect
 class iob_picorv32(iob_module):
     def __init__(self):
         super().__init__()
-        self.name = 'iob_picorv32'
         self.version = 'V0.10'
         self.setup_dir = os.path.dirname(__file__)
         self.submodule_list = [


### PR DESCRIPTION
Check commits for details.

Major changes:
- Update iob_picorv32.py with previously agreed-upon py2hw syntax.
- Merged branch 'deprecate-REQ' of P-Miranda/iob-picorv32 into this py2hw branch.
- Removed deprecated `iob_utils.vh` references from Verilog source.