### PR TITLE
Fix bug in iob_picorv32_core.v

### DIFF
--- a/hardware/src/iob_picorv32_core.v
+++ b/hardware/src/iob_picorv32_core.v
@@ -373,9 +373,9 @@ module picorv32 #(
    wire        mem_xfer;
    reg mem_la_secondword, mem_la_firstword_reg, last_mem_valid;
    wire       mem_la_firstword;
-   assign       mem_la_firstword = COMPRESSED_ISA && (mem_do_prefetch || mem_do_rinst) && next_pc&& !mem_la_secondword;
+   assign     mem_la_firstword = COMPRESSED_ISA && (mem_do_prefetch || mem_do_rinst) && next_pc[1] && !mem_la_secondword;
    wire       mem_la_firstword_xfer;
-   assign       mem_la_firstword_xfer = COMPRESSED_ISA && mem_xfer && (!last_mem_valid ? mem_la_firstword : mem_la_firstword_reg);
+   assign     mem_la_firstword_xfer = COMPRESSED_ISA && mem_xfer && (!last_mem_valid ? mem_la_firstword : mem_la_firstword_reg);
 
    reg prefetched_high_word;
    reg clear_prefetched_high_word;


### PR DESCRIPTION
Fix bug introduced by this commit: https://github.com/IObundle/py2hwsw/commit/2fdb618b3ec8d04bd8273c0a3857431323587492#diff-abb72eec40d082219555ff72fd9d24f3a245db7e56eb5cfd1bfbc64364b823ef

With this fix, iob_picorv32 is working well in iob_system.